### PR TITLE
Update ffi-napi to latest 2.x release

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
-    "ffi-napi": "2.4.5",
+    "ffi-napi": "2.5.0",
     "ref-array-napi": "1.2.0",
     "ref-napi": "1.4.2"
   },


### PR DESCRIPTION
<!--
Thanks for contributing to the project!
Please help us keep this project in good shape by going through this checklist.
Replace the empty checkboxes [ ] below with checked ones [X] as they are completed
Remember, you can preview this before saving it.
-->

<!-- You can remove this first section if you have contributed before -->

### First time contributor checklist:

- [X] I have read the [README](https://github.com/signalapp/Signal-Desktop/blob/master/README.md) and [Contributor Guidelines](https://github.com/signalapp/Signal-Desktop/blob/master/CONTRIBUTING.md)
- [X] I have signed the [Contributor Licence Agreement](https://signal.org/cla/)

### Contributor checklist:

- [X] My contribution is **not** related to translations. _Please submit translation changes via our [Signal Desktop Transifex project](https://www.transifex.com/signalapp/signal-desktop/)._
- [X] My commits are in nice logical chunks with [good commit messages](http://chris.beams.io/posts/git-commit/)
- [X] My changes are [rebased](https://medium.freecodecamp.org/git-rebase-and-the-golden-rule-explained-70715eccc372) on the latest [`development`](https://github.com/signalapp/Signal-Desktop/tree/development) branch
- [ ] A `yarn ready` run passes successfully ([more about tests here](https://github.com/signalapp/Signal-Desktop/blob/master/CONTRIBUTING.md#tests))
- [ ] My changes are ready to be shipped to users

### Description

Allow building the library on aarch64/arm64 devices by upgrading the Node Foreign Function Interface (FFI) library, provided by [node-ffi-napi](https://github.com/node-ffi-napi/node-ffi-napi) to the latest 2.x version.

This work is part of https://github.com/signalapp/Signal-Desktop/issues/3410

build output from my pinephone, running mobian:
`Linux mobian 5.7-pinephone #1 SMP PREEMPT Fri Sep 4 14:55:26 UTC 2020 aarch64 GNU/Linux`

```log
$ npm install

> ref-napi@1.5.2 install /home/mobian/git/olof-signal-zkgroup-node/node_modules/ffi-napi/node_modules/ref-napi
> node-gyp-build

make: Entering directory '/home/mobian/git/olof-signal-zkgroup-node/node_modules/ffi-napi/node_modules/ref-napi/build'
  CC(target) Release/obj.target/nothing/node_modules/node-addon-api/src/nothing.o
  AR(target) Release/obj.target/node_modules/node-addon-api/src/nothing.a
  COPY Release/nothing.a
  CXX(target) Release/obj.target/binding/src/binding.o
  SOLINK_MODULE(target) Release/obj.target/binding.node
  COPY Release/binding.node
make: Leaving directory '/home/mobian/git/olof-signal-zkgroup-node/node_modules/ffi-napi/node_modules/ref-napi/build'

> ref-napi@1.4.2 install /home/mobian/git/olof-signal-zkgroup-node/node_modules/ref-napi
> node-gyp rebuild

make: Entering directory '/home/mobian/git/olof-signal-zkgroup-node/node_modules/ref-napi/build'
  CC(target) Release/obj.target/nothing/node_modules/node-addon-api/src/nothing.o
  AR(target) Release/obj.target/node_modules/node-addon-api/src/nothing.a
  COPY Release/nothing.a
  CXX(target) Release/obj.target/binding/src/binding.o
  SOLINK_MODULE(target) Release/obj.target/binding.node
  COPY Release/binding.node
make: Leaving directory '/home/mobian/git/olof-signal-zkgroup-node/node_modules/ref-napi/build'

> ffi-napi@2.5.0 install /home/mobian/git/olof-signal-zkgroup-node/node_modules/ffi-napi
> node-gyp-build

make: Entering directory '/home/mobian/git/olof-signal-zkgroup-node/node_modules/ffi-napi/build'
  CC(target) Release/obj.target/nothing/../node-addon-api/src/nothing.o
  AR(target) Release/obj.target/../node-addon-api/src/nothing.a
  COPY Release/nothing.a
  CC(target) Release/obj.target/ffi/deps/libffi/src/prep_cif.o
  CC(target) Release/obj.target/ffi/deps/libffi/src/types.o
  CC(target) Release/obj.target/ffi/deps/libffi/src/raw_api.o
  CC(target) Release/obj.target/ffi/deps/libffi/src/java_raw_api.o
  CC(target) Release/obj.target/ffi/deps/libffi/src/closures.o
  CC(target) Release/obj.target/ffi/deps/libffi/src/aarch64/ffi.o
  CC(target) Release/obj.target/ffi/deps/libffi/src/aarch64/sysv.o
  AR(target) Release/obj.target/deps/libffi/libffi.a
  COPY Release/libffi.a
  CXX(target) Release/obj.target/ffi_bindings/src/ffi.o
  CXX(target) Release/obj.target/ffi_bindings/src/callback_info.o
  CXX(target) Release/obj.target/ffi_bindings/src/threaded_callback_invokation.o
  SOLINK_MODULE(target) Release/obj.target/ffi_bindings.node
  COPY Release/ffi_bindings.node
make: Leaving directory '/home/mobian/git/olof-signal-zkgroup-node/node_modules/ffi-napi/build'
npm WARN zkgroup@0.7.1 No repository field.
npm WARN optional SKIPPING OPTIONAL DEPENDENCY: fsevents@2.1.2 (node_modules/fsevents):
npm WARN notsup SKIPPING OPTIONAL DEPENDENCY: Unsupported platform for fsevents@2.1.2: wanted {"os":"darwin","arch":"any"} (current: {"os":"linux","arch":"arm64"})

added 145 packages from 194 contributors and audited 147 packages in 99.766s
found 1 low severity vulnerability
  run `npm audit fix` to fix them, or `npm audit` for details

```

<!--
Describe briefly what your pull request changes. Focus on the value provided to users.

Does it address any outstanding issues in this project?
  https://github.com/signalapp/Signal-Desktop/issues?utf8=%E2%9C%93&q=is%3Aissue
  Reference an issue with the hash symbol: "#222"
  If you're fixing it, use something like "Fixes #222"

Please write a summary of your test approach:
  - What kind of manual testing did you do?
  - Did you write any new tests?
  - What operating systems did you test with? (please use specific versions: http://whatsmyos.com/)
  - What other devices did you test with? (other Desktop devices, Android, Android Simulator, iOS, iOS Simulator)
-->

With the previous version of ffi-napi no build is possible as ffi-napi does not support aarch64:
```log
$ npm install

> ffi-napi@2.4.5 install /home/mobian/git/olof-signal-zkgroup-node/node_modules/ffi-napi
> node-gyp rebuild

make: Entering directory '/home/mobian/git/olof-signal-zkgroup-node/node_modules/ffi-napi/build'
  CC(target) Release/obj.target/nothing/../node-addon-api/src/nothing.o
  AR(target) Release/obj.target/../node-addon-api/src/nothing.a
  COPY Release/nothing.a
  CC(target) Release/obj.target/ffi/deps/libffi/src/prep_cif.o
  CC(target) Release/obj.target/ffi/deps/libffi/src/types.o
  CC(target) Release/obj.target/ffi/deps/libffi/src/raw_api.o
  CC(target) Release/obj.target/ffi/deps/libffi/src/java_raw_api.o
../deps/libffi/src/java_raw_api.c: In function ‘ffi_java_raw_call’:
../deps/libffi/src/java_raw_api.c:299:3: warning: ‘ffi_java_raw_to_ptrarray’ is deprecated [-Wdeprecated-declarations]
  299 |   ffi_java_raw_to_ptrarray (cif, raw, avalue);
      |   ^~~~~~~~~~~~~~~~~~~~~~~~
In file included from ../deps/libffi/src/java_raw_api.c:38:
/usr/local/include/ffi.h:297:6: note: declared here
  297 | void ffi_java_raw_to_ptrarray (ffi_cif *cif, ffi_java_raw *raw, void **args) __attribute__((deprecated));
      |      ^~~~~~~~~~~~~~~~~~~~~~~~
../deps/libffi/src/java_raw_api.c: In function ‘ffi_java_translate_args’:
../deps/libffi/src/java_raw_api.c:310:3: warning: ‘ffi_java_raw_size’ is deprecated [-Wdeprecated-declarations]
  310 |   ffi_java_raw *raw = (ffi_java_raw*)alloca (ffi_java_raw_size (cif));
      |   ^~~~~~~~~~~~
In file included from ../deps/libffi/src/java_raw_api.c:38:
/usr/local/include/ffi.h:299:8: note: declared here
  299 | size_t ffi_java_raw_size (ffi_cif *cif) __attribute__((deprecated));
      |        ^~~~~~~~~~~~~~~~~
../deps/libffi/src/java_raw_api.c:313:3: warning: ‘ffi_java_ptrarray_to_raw’ is deprecated [-Wdeprecated-declarations]
  313 |   ffi_java_ptrarray_to_raw (cif, avalue, raw);
      |   ^~~~~~~~~~~~~~~~~~~~~~~~
In file included from ../deps/libffi/src/java_raw_api.c:38:
/usr/local/include/ffi.h:295:6: note: declared here
  295 | void ffi_java_ptrarray_to_raw (ffi_cif *cif, void **args, ffi_java_raw *raw) __attribute__((deprecated));
      |      ^~~~~~~~~~~~~~~~~~~~~~~~
../deps/libffi/src/java_raw_api.c: In function ‘ffi_prep_java_raw_closure’:
../deps/libffi/src/java_raw_api.c:351:3: warning: ‘ffi_prep_java_raw_closure_loc’ is deprecated [-Wdeprecated-declarations]
  351 |   return ffi_prep_java_raw_closure_loc (cl, cif, fun, user_data, cl);
      |   ^~~~~~
In file included from ../deps/libffi/src/java_raw_api.c:38:
/usr/local/include/ffi.h:435:1: note: declared here
  435 | ffi_prep_java_raw_closure_loc (ffi_java_raw_closure*,
      | ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~
  CC(target) Release/obj.target/ffi/deps/libffi/src/closures.o
  CC(target) Release/obj.target/ffi/deps/libffi/src/x86/ffi.o
../deps/libffi/src/x86/ffi.c: In function ‘ffi_prep_args’:
../deps/libffi/src/x86/ffi.c:62:31: error: ‘FFI_TYPE_MS_STRUCT’ undeclared (first use in this function); did you mean ‘FFI_TYPE_STRUCT’?
   62 |        || ecif->cif->flags == FFI_TYPE_MS_STRUCT)
      |                               ^~~~~~~~~~~~~~~~~~
      |                               FFI_TYPE_STRUCT
../deps/libffi/src/x86/ffi.c:62:31: note: each undeclared identifier is reported only once for each function it appears in
../deps/libffi/src/x86/ffi.c: In function ‘ffi_prep_cif_machdep’:
../deps/libffi/src/x86/ffi.c:262:24: error: ‘FFI_TYPE_SMALL_STRUCT_1B’ undeclared (first use in this function)
  262 |           cif->flags = FFI_TYPE_SMALL_STRUCT_1B; /* same as char size */
      |                        ^~~~~~~~~~~~~~~~~~~~~~~~
../deps/libffi/src/x86/ffi.c:266:24: error: ‘FFI_TYPE_SMALL_STRUCT_2B’ undeclared (first use in this function)
  266 |           cif->flags = FFI_TYPE_SMALL_STRUCT_2B; /* same as short size */
      |                        ^~~~~~~~~~~~~~~~~~~~~~~~
../deps/libffi/src/x86/ffi.c: In function ‘ffi_call’:
../deps/libffi/src/x86/ffi.c:359:28: error: ‘FFI_TYPE_MS_STRUCT’ undeclared (first use in this function); did you mean ‘FFI_TYPE_STRUCT’?
  359 |           || cif->flags == FFI_TYPE_MS_STRUCT))
      |                            ^~~~~~~~~~~~~~~~~~
      |                            FFI_TYPE_STRUCT
../deps/libffi/src/x86/ffi.c: At top level:
../deps/libffi/src/x86/ffi.c:431:6: warning: ‘regparm’ attribute directive ignored [-Wattributes]
  431 |      __attribute__ ((regparm(1)));
      |      ^~~~~~~~~~~~~
../deps/libffi/src/x86/ffi.c:433:6: warning: ‘regparm’ attribute directive ignored [-Wattributes]
  433 |      __attribute__ ((regparm(1)));
      |      ^~~~~~~~~~~~~
../deps/libffi/src/x86/ffi.c:435:6: warning: ‘regparm’ attribute directive ignored [-Wattributes]
  435 |      __attribute__ ((regparm(1)));
      |      ^~~~~~~~~~~~~
../deps/libffi/src/x86/ffi.c:482:1: warning: ‘regparm’ attribute directive ignored [-Wattributes]
  482 | {
      | ^
../deps/libffi/src/x86/ffi.c: In function ‘ffi_prep_incoming_args_SYSV’:
../deps/libffi/src/x86/ffi.c:525:25: error: ‘FFI_TYPE_MS_STRUCT’ undeclared (first use in this function); did you mean ‘FFI_TYPE_STRUCT’?
  525 |        || cif->flags == FFI_TYPE_MS_STRUCT ) {
      |                         ^~~~~~~~~~~~~~~~~~
      |                         FFI_TYPE_STRUCT
../deps/libffi/src/x86/ffi.c: In function ‘ffi_prep_closure_loc’:
../deps/libffi/src/x86/ffi.c:594:26: warning: cast from pointer to integer of different size [-Wpointer-to-int-cast]
  594 |    unsigned int  __fun = (unsigned int)(FUN); \
      |                          ^
../deps/libffi/src/x86/ffi.c:667:7: note: in expansion of macro ‘FFI_INIT_TRAMPOLINE’
  667 |       FFI_INIT_TRAMPOLINE (&closure->tramp[0],
      |       ^~~~~~~~~~~~~~~~~~~
../deps/libffi/src/x86/ffi.c:595:26: warning: cast from pointer to integer of different size [-Wpointer-to-int-cast]
  595 |    unsigned int  __ctx = (unsigned int)(CTX); \
      |                          ^
../deps/libffi/src/x86/ffi.c:667:7: note: in expansion of macro ‘FFI_INIT_TRAMPOLINE’
  667 |       FFI_INIT_TRAMPOLINE (&closure->tramp[0],
      |       ^~~~~~~~~~~~~~~~~~~
../deps/libffi/src/x86/ffi.c: In function ‘ffi_prep_raw_closure_loc’:
../deps/libffi/src/x86/ffi.c:594:26: warning: cast from pointer to integer of different size [-Wpointer-to-int-cast]
  594 |    unsigned int  __fun = (unsigned int)(FUN); \
      |                          ^
../deps/libffi/src/x86/ffi.c:740:3: note: in expansion of macro ‘FFI_INIT_TRAMPOLINE’
  740 |   FFI_INIT_TRAMPOLINE (&closure->tramp[0], &ffi_closure_raw_SYSV,
      |   ^~~~~~~~~~~~~~~~~~~
../deps/libffi/src/x86/ffi.c:595:26: warning: cast from pointer to integer of different size [-Wpointer-to-int-cast]
  595 |    unsigned int  __ctx = (unsigned int)(CTX); \
      |                          ^
../deps/libffi/src/x86/ffi.c:740:3: note: in expansion of macro ‘FFI_INIT_TRAMPOLINE’
  740 |   FFI_INIT_TRAMPOLINE (&closure->tramp[0], &ffi_closure_raw_SYSV,
      |   ^~~~~~~~~~~~~~~~~~~
../deps/libffi/src/x86/ffi.c: In function ‘ffi_raw_call’:
../deps/libffi/src/x86/ffi.c:782:28: error: ‘FFI_TYPE_MS_STRUCT’ undeclared (first use in this function); did you mean ‘FFI_TYPE_STRUCT’?
  782 |           || cif->flags == FFI_TYPE_MS_STRUCT))
      |                            ^~~~~~~~~~~~~~~~~~
      |                            FFI_TYPE_STRUCT
make: *** [deps/libffi/ffi.target.mk:127: Release/obj.target/ffi/deps/libffi/src/x86/ffi.o] Error 1
make: Leaving directory '/home/mobian/git/olof-signal-zkgroup-node/node_modules/ffi-napi/build'
gyp ERR! build error 
gyp ERR! stack Error: `make` failed with exit code: 2
gyp ERR! stack     at ChildProcess.onExit (/home/mobian/.nvm/versions/node/v12.13.0/lib/node_modules/npm/node_modules/node-gyp/lib/build.js:194:23)
gyp ERR! stack     at ChildProcess.emit (events.js:210:5)
gyp ERR! stack     at Process.ChildProcess._handle.onexit (internal/child_process.js:272:12)
gyp ERR! System Linux 5.7-pinephone
gyp ERR! command "/home/mobian/.nvm/versions/node/v12.13.0/bin/node" "/home/mobian/.nvm/versions/node/v12.13.0/lib/node_modules/npm/node_modules/node-gyp/bin/node-gyp.js" "rebuild"
gyp ERR! cwd /home/mobian/git/olof-signal-zkgroup-node/node_modules/ffi-napi
gyp ERR! node -v v12.13.0
gyp ERR! node-gyp -v v5.0.5
gyp ERR! not ok 
npm WARN zkgroup@0.7.1 No repository field.
npm WARN optional SKIPPING OPTIONAL DEPENDENCY: fsevents@2.1.2 (node_modules/fsevents):
npm WARN notsup SKIPPING OPTIONAL DEPENDENCY: Unsupported platform for fsevents@2.1.2: wanted {"os":"darwin","arch":"any"} (current: {"os":"linux","arch":"arm64"})

npm ERR! code ELIFECYCLE
npm ERR! errno 1
npm ERR! ffi-napi@2.4.5 install: `node-gyp rebuild`
npm ERR! Exit status 1
npm ERR! 
npm ERR! Failed at the ffi-napi@2.4.5 install script.
npm ERR! This is probably not a problem with npm. There is likely additional logging output above.

npm ERR! A complete log of this run can be found in:
npm ERR!     /home/mobian/.npm/_logs/2020-09-18T16_35_01_186Z-debug.log

```
